### PR TITLE
help to fix code for kernel 5.19 API change

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -567,8 +567,11 @@ post_process:
 
 _func_exit_;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	thread_exit();
-
+#else
+	kthread_complete_and_exit(NULL, 0);
+#endif
 }
 
 

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -853,7 +853,11 @@ __inline static void _set_workitem(_workitem *pwork)
 	typedef int		thread_return;
 	typedef void*	thread_context;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	#define thread_exit() complete_and_exit(NULL, 0)
+#else
+	#define kthread_thread_exit() complete_and_exit(NULL, 0)
+#endif
 
 	typedef void timer_hdl_return;
 	typedef void* timer_hdl_context;
@@ -1114,7 +1118,11 @@ static inline void rtw_netif_stop_queue(struct net_device *pnetdev)
 
 	typedef NDIS_WORK_ITEM _workitem;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	#define thread_exit() PsTerminateSystemThread(STATUS_SUCCESS);
+#else
+	#define kthread_thread_exit() PsTerminateSystemThread(STATUS_SUCCESS);
+#endif
 
 	#define HZ			10000000
 	#define SEMA_UPBND	(0x7FFFFFFF)   //8192


### PR DESCRIPTION
i am sorry for my english, this is not my first language!

i am used this driver for rtl8192cu usb wireless network card in arch linux.

i tried rtl8xxxu driver, it's extremely slow. this driver is worked well until kernel 5.19.

and i tried fix compile issue, but i'm not good at c language and hardware programing.

i am use windows11 instead arch linux now, please fix it if you have time and pleasure.

thanks and respect !